### PR TITLE
Add package.json for clib.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sort_r",
+  "version": "1.0.0",
+  "repo": "noporpoise/sort_r",
+  "description": "Portable qsort_r / qsort_s",
+  "keywords": ["portable", "qsort", "qsort_s", "qsort_r"],
+  "license": "PD",
+  "src": [
+    "sort_r.h"
+  ]
+}


### PR DESCRIPTION
Add `package.json` to allow [clib(1)](https://github.com/clibs/clib) to install this repo.

To allow clib to install version `1.0.0`, your repo also needs an appropriate `1.0.0` tag:
```sh
git tag 1.0.0 && git push --tags
```

To allow clib to find this repo, add an appropriate entry to the wiki:
https://github.com/clibs/clib/wiki/Packages

:tada:  