### PR TITLE
Prevent MinGW from searching for glibc on Windows

### DIFF
--- a/sort_r.h
+++ b/sort_r.h
@@ -28,7 +28,7 @@ void sort_r(void *base, size_t nel, size_t width,
      defined __FreeBSD__ || defined __DragonFly__)
 #  define _SORT_R_BSD
 #elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
-       defined __linux__ || defined __MINGW32__ || defined __GLIBC__)
+       defined __linux__ || defined __GLIBC__)
 #  define _SORT_R_LINUX
 #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
 #  define _SORT_R_WINDOWS


### PR DESCRIPTION
Due to the order of defines in sort_r.h, compiling the code using MinGW leads to a (unsuccessful) search for glibc. Unfortunately, MinGW provides Unix compilers (gcc, g++), but not the C standard library, It is "designed to build native Windows code, and as such it builds against Windows' native libc" (https://stackoverflow.com/questions/6394512/standard-c-library-in-mingw).
Thus, the right (and simple) solution seems to be to have the compiler identify the correct (host) system.  