### PR TITLE
Improve qsort_r detection on a future version of FreeBSD.

### DIFF
--- a/sort_r.h
+++ b/sort_r.h
@@ -25,10 +25,11 @@ void sort_r(void *base, size_t nel, size_t width,
 #define _SORT_R_INLINE inline
 
 #if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
-     defined __FreeBSD__ || defined __DragonFly__)
+     (defined __FreeBSD__ && !defined(qsort_r)) || defined __DragonFly__)
 #  define _SORT_R_BSD
 #elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
-       defined __linux__ || defined __MINGW32__ || defined __GLIBC__)
+       defined __linux__ || defined __MINGW32__ || defined __GLIBC__ || \
+       (defined (__FreeBSD__) && defined(qsort_r)))
 #  define _SORT_R_LINUX
 #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
 #  define _SORT_R_WINDOWS
@@ -263,7 +264,7 @@ static _SORT_R_INLINE void sort_r_simple(void *base, size_t nel, size_t w,
   #if defined _SORT_R_LINUX
 
     typedef int(* __compar_d_fn_t)(const void *, const void *, void *);
-    extern void qsort_r(void *base, size_t nel, size_t width,
+    extern void (qsort_r)(void *base, size_t nel, size_t width,
                         __compar_d_fn_t __compar, void *arg)
       __attribute__((nonnull (1, 4)));
 


### PR DESCRIPTION
The Austin Group is standardizing qsort_r(3) in an upcoming revision of the standard, and FreeBSD will adopt the standarized qsort_r(3) interface in future releases, and source level compatibility will be maintained by using C _Generic, which will be available as a macro called qsort_r.

Detect this on FreeBSD by checking the existence of qsort_r, and use the GNU function signature, which will be a direct call of qsort_r and avoids the translations.