### PR TITLE
Use Windows qsort_s() if MINGW detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sort_r
 ======
 
-Isaac Turner 2022
+Isaac Turner 2022  
 Portable qsort_r / qsort_s  
 Discussion here: http://stackoverflow.com/questions/4300896/how-portable-is-the-re-entrant-qsort-r-function-compared-to-qsort  
 License: Public Domain - use as you wish, no warranty

--- a/sort_r.h
+++ b/sort_r.h
@@ -28,10 +28,11 @@ void sort_r(void *base, size_t nel, size_t width,
      (defined __FreeBSD__ && !defined(qsort_r)) || defined __DragonFly__)
 #  define _SORT_R_BSD
 #elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
-       defined __linux__ || defined __MINGW32__ || defined __GLIBC__ || \
+       defined __linux__ || defined __GLIBC__ || \
        (defined (__FreeBSD__) && defined(qsort_r)))
 #  define _SORT_R_LINUX
-#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
+#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__ || \
+       defined __MINGW32__ || defined __MINGW64__)
 #  define _SORT_R_WINDOWS
 #  undef _SORT_R_INLINE
 #  define _SORT_R_INLINE __inline


### PR DESCRIPTION
If MINGW32 or MINGW64 detected, use Windows `qsort_s()` method.

Closes issue #14. Alternative approach to PR #13.
