### PR TITLE
Only rely on __GLIBC__ macro for qsort_r()

### DIFF
--- a/sort_r.h
+++ b/sort_r.h
@@ -3,7 +3,7 @@
 #define SORT_R_H_
 
 #include <stdlib.h>
-#include <string.h>
+#include <string.h> /* needed for memcpy() */
 
 /*
 

--- a/sort_r.h
+++ b/sort_r.h
@@ -266,7 +266,7 @@ static _SORT_R_INLINE void sort_r_simple(void *base, size_t nel, size_t w,
 
     typedef int(* __compar_d_fn_t)(const void *, const void *, void *);
     extern void (qsort_r)(void *base, size_t nel, size_t width,
-                        __compar_d_fn_t __compar, void *arg)
+                          __compar_d_fn_t __compar, void *arg)
       __attribute__((nonnull (1, 4)));
 
   #endif

--- a/sort_r.h
+++ b/sort_r.h
@@ -2,7 +2,7 @@
 #ifndef SORT_R_H_
 #define SORT_R_H_
 
-#include <stdlib.h>
+#include <stdlib.h> /* qsort_r(), qsort_s() */
 #include <string.h> /* needed for memcpy() */
 
 /*
@@ -27,9 +27,7 @@ void sort_r(void *base, size_t nel, size_t width,
 #if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
      (defined __FreeBSD__ && !defined(qsort_r)) || defined __DragonFly__)
 #  define _SORT_R_BSD
-#elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
-       defined __linux__ || defined __GLIBC__ || \
-       (defined (__FreeBSD__) && defined(qsort_r)))
+#elif (defined __GLIBC__ || (defined (__FreeBSD__) && defined(qsort_r)))
 #  define _SORT_R_LINUX
 #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__ || \
        defined __MINGW32__ || defined __MINGW64__)


### PR DESCRIPTION
Attempt to fix issues like #12, where linux platforms don't use glibc.
